### PR TITLE
Add GUI launcher and packaging guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# Renamer
+
+디렉터리 안에 있는 파일 이름을 텍스트 파일로 저장하는 간단한 도구입니다. 파이썬 3.10 이상에서 동작하며 추가 의존성이 없습니다.
+
+## 사용 방법
+
+```bash
+python renamer.py <대상_폴더_경로> [옵션]
+```
+
+예시:
+
+- 지정한 폴더의 파일 이름을 `filenames.txt`로 생성
+
+  ```bash
+  python renamer.py ./my_folder
+  ```
+
+- 하위 폴더까지 모두 포함해 `output/list.txt`로 저장
+
+  ```bash
+  python renamer.py ./my_folder -r -o output/list.txt
+  ```
+
+- 숨김 파일까지 포함하려면 `--include-hidden` 옵션을 추가하세요.
+
+옵션 요약:
+
+- `-o, --output`: 결과를 기록할 텍스트 파일 경로 (기본값: `filenames.txt`)
+- `-r, --recursive`: 하위 폴더까지 검색
+- `--include-hidden`: 숨김 파일/폴더도 포함
+
+## GUI 사용
+
+```bash
+python renamer.py --gui
+```
+
+또는 아무 인자 없이 실행하면 자동으로 GUI가 열립니다. 폴더와 저장 위치를 선택하고, 하위 폴더/숨김 파일 포함 여부를 체크한 뒤 **파일 목록 생성** 버튼을 누르면 됩니다.
+
+## Windows용 실행 파일 만들기
+
+`pyinstaller`를 사용해 GUI 전용 실행 파일을 만들 수 있습니다.
+
+```bash
+pip install pyinstaller
+pyinstaller --onefile --windowed --name Renamer renamer.py
+```
+
+생성된 `dist/Renamer.exe`를 실행하면 바로 GUI가 열립니다.
+
+## 개발
+
+테스트 실행:
+
+```bash
+pytest
+```

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/renamer.py
+++ b/renamer.py
@@ -1,0 +1,264 @@
+"""Utility to write the names of files inside a directory to a text file.
+
+The module exposes helpers for listing files and a small CLI for convenience.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable, List
+
+import tkinter as tk
+from tkinter import filedialog, messagebox, ttk
+
+
+def list_files(
+    source_dir: Path, *, recursive: bool = False, include_hidden: bool = False
+) -> List[str]:
+    """Return sorted file names inside *source_dir*.
+
+    Args:
+        source_dir: The directory to scan for files.
+        recursive: When ``True``, include files in all subdirectories.
+        include_hidden: When ``True``, include files and subdirectories whose names
+            start with ``.``.
+
+    Raises:
+        ValueError: If *source_dir* does not exist or is not a directory.
+    """
+
+    if not source_dir.exists():
+        raise ValueError(f"Source directory '{source_dir}' does not exist.")
+    if not source_dir.is_dir():
+        raise ValueError(f"Source path '{source_dir}' is not a directory.")
+
+    if recursive:
+        entries: Iterable[Path] = (
+            path for path in source_dir.rglob("*") if path.is_file()
+        )
+    else:
+        entries = (path for path in source_dir.iterdir() if path.is_file())
+
+    filenames: List[str] = []
+    for path in entries:
+        relative = path.relative_to(source_dir)
+        if not include_hidden and any(part.startswith(".") for part in relative.parts):
+            continue
+        filenames.append(relative.as_posix())
+
+    return sorted(filenames)
+
+
+def write_file_list(
+    source_dir: Path,
+    output_file: Path,
+    *,
+    recursive: bool = False,
+    include_hidden: bool = False,
+) -> None:
+    """Write the names of files inside *source_dir* to *output_file*.
+
+    The output file is created (with parent directories) if it does not exist and
+    is overwritten if it already exists.
+    """
+
+    filenames = list_files(source_dir, recursive=recursive, include_hidden=include_hidden)
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text("\n".join(filenames), encoding="utf-8")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate a text file that lists the names of files in the provided directory."
+        )
+    )
+    parser.add_argument(
+        "source",
+        nargs="?",
+        type=Path,
+        help="Directory whose files will be listed.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=Path("filenames.txt"),
+        help="Path of the text file to write (default: filenames.txt).",
+    )
+    parser.add_argument(
+        "-r",
+        "--recursive",
+        action="store_true",
+        help="Include files in all subdirectories.",
+    )
+    parser.add_argument(
+        "--include-hidden",
+        action="store_true",
+        help="Include hidden files and folders (names starting with '.').",
+    )
+    parser.add_argument(
+        "--gui",
+        action="store_true",
+        help="Launch the graphical interface instead of the CLI.",
+    )
+    return parser
+
+
+class FileListGUI:
+    """Simple GUI for exporting directory file names."""
+
+    def __init__(self) -> None:
+        self.root = tk.Tk()
+        self.root.title("파일 목록 생성기")
+        self.root.geometry("520x260")
+        self.root.resizable(False, False)
+
+        self.source_var = tk.StringVar()
+        self.output_var = tk.StringVar(value="filenames.txt")
+        self.recursive_var = tk.BooleanVar(value=False)
+        self.hidden_var = tk.BooleanVar(value=False)
+        self.status_var = tk.StringVar(value="대상 폴더를 선택하고 옵션을 설정하세요.")
+
+        self._build_layout()
+
+    def _build_layout(self) -> None:
+        main = ttk.Frame(self.root, padding=16)
+        main.pack(fill=tk.BOTH, expand=True)
+
+        title = ttk.Label(
+            main,
+            text="폴더 내 파일 이름을 텍스트로 저장",
+            font=("Helvetica", 14, "bold"),
+        )
+        title.pack(anchor=tk.W, pady=(0, 12))
+
+        self._add_path_field(
+            main,
+            label="대상 폴더",
+            variable=self.source_var,
+            browse_command=self._choose_source,
+            is_directory=True,
+        )
+        self._add_path_field(
+            main,
+            label="출력 파일",
+            variable=self.output_var,
+            browse_command=self._choose_output,
+            is_directory=False,
+        )
+
+        options = ttk.Frame(main)
+        options.pack(fill=tk.X, pady=(12, 8))
+        ttk.Checkbutton(options, text="하위 폴더 포함", variable=self.recursive_var).pack(
+            side=tk.LEFT, padx=(0, 16)
+        )
+        ttk.Checkbutton(options, text="숨김 파일 포함", variable=self.hidden_var).pack(
+            side=tk.LEFT
+        )
+
+        action_row = ttk.Frame(main)
+        action_row.pack(fill=tk.X, pady=(4, 8))
+        ttk.Button(action_row, text="파일 목록 생성", command=self._generate).pack(
+            side=tk.RIGHT
+        )
+
+        status = ttk.Label(main, textvariable=self.status_var, foreground="#0d6efd")
+        status.pack(anchor=tk.W, pady=(8, 0))
+
+    def _add_path_field(
+        self,
+        parent: ttk.Frame,
+        *,
+        label: str,
+        variable: tk.StringVar,
+        browse_command,
+        is_directory: bool,
+    ) -> None:
+        row = ttk.Frame(parent)
+        row.pack(fill=tk.X, pady=4)
+
+        ttk.Label(row, text=label, width=10).pack(side=tk.LEFT)
+
+        entry = ttk.Entry(row, textvariable=variable)
+        entry.pack(side=tk.LEFT, fill=tk.X, expand=True, padx=(4, 8))
+
+        button_text = "폴더 선택" if is_directory else "경로 선택"
+        ttk.Button(row, text=button_text, command=browse_command).pack(side=tk.RIGHT)
+
+    def _choose_source(self) -> None:
+        directory = filedialog.askdirectory(title="대상 폴더 선택")
+        if directory:
+            self.source_var.set(directory)
+
+    def _choose_output(self) -> None:
+        file_path = filedialog.asksaveasfilename(
+            title="출력 파일 경로",  # type: ignore[arg-type]
+            defaultextension=".txt",
+            filetypes=[("Text Files", "*.txt"), ("All Files", "*.*")],
+            initialfile=Path(self.output_var.get()).name or "filenames.txt",
+        )
+        if file_path:
+            self.output_var.set(file_path)
+
+    def _generate(self) -> None:
+        source = Path(self.source_var.get()).expanduser()
+        output = Path(self.output_var.get()).expanduser()
+
+        if not self.source_var.get().strip():
+            messagebox.showwarning("대상 없음", "대상 폴더를 선택하세요.")
+            return
+        if not self.output_var.get().strip():
+            messagebox.showwarning("출력 없음", "출력 파일 경로를 입력하세요.")
+            return
+
+        try:
+            filenames = list_files(
+                source,
+                recursive=self.recursive_var.get(),
+                include_hidden=self.hidden_var.get(),
+            )
+        except ValueError as exc:
+            messagebox.showerror("경로 오류", str(exc))
+            self.status_var.set("경로를 다시 확인해주세요.")
+            return
+
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text("\n".join(filenames), encoding="utf-8")
+
+        self.status_var.set(f"총 {len(filenames)}개 파일 이름을 저장했습니다.")
+        messagebox.showinfo("완료", f"파일 목록을 저장했습니다:\n{output}")
+
+    def run(self) -> None:
+        self.root.mainloop()
+
+
+def launch_gui() -> None:
+    """Start the Tkinter-based graphical interface."""
+
+    app = FileListGUI()
+    app.run()
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.gui or args.source is None:
+        launch_gui()
+        return 0
+
+    try:
+        write_file_list(
+            args.source,
+            args.output,
+            recursive=args.recursive,
+            include_hidden=args.include_hidden,
+        )
+    except ValueError as exc:  # argparse expects SystemExit on errors
+        parser.error(str(exc))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_renamer.py
+++ b/tests/test_renamer.py
@@ -1,0 +1,92 @@
+from pathlib import Path
+
+import pytest
+
+import renamer
+
+
+def create_files(base: Path, structure: dict[str, str | dict]):
+    """Recursively create files from a mapping for testing."""
+    base.mkdir(parents=True, exist_ok=True)
+    for name, content in structure.items():
+        path = base / name
+        if isinstance(content, dict):
+            path.mkdir()
+            create_files(path, content)
+        else:
+            path.write_text(content)
+
+
+def test_list_files_non_recursive(tmp_path: Path):
+    create_files(
+        tmp_path,
+        {
+            "a.txt": "A",
+            "b.md": "B",
+            "nested": {
+                "c.txt": "C",
+            },
+        },
+    )
+
+    assert renamer.list_files(tmp_path) == ["a.txt", "b.md"]
+
+
+def test_list_files_recursive(tmp_path: Path):
+    create_files(
+        tmp_path,
+        {
+            "a.txt": "A",
+            "nested": {
+                "b.md": "B",
+                "deep": {"c.log": "C"},
+            },
+        },
+    )
+
+    assert renamer.list_files(tmp_path, recursive=True) == [
+        "a.txt",
+        "nested/b.md",
+        "nested/deep/c.log",
+    ]
+
+
+def test_excludes_hidden_by_default(tmp_path: Path):
+    create_files(
+        tmp_path,
+        {
+            ".hidden.txt": "H",
+            "visible.txt": "V",
+            ".folder": {"inside.txt": "I"},
+            "folder": {".hidden2": "H2", "ok.txt": "O"},
+        },
+    )
+
+    assert renamer.list_files(tmp_path, recursive=True) == ["folder/ok.txt", "visible.txt"]
+
+
+def test_include_hidden_when_requested(tmp_path: Path):
+    create_files(tmp_path, {".hidden.txt": "H"})
+
+    assert renamer.list_files(tmp_path, include_hidden=True) == [".hidden.txt"]
+
+
+def test_invalid_directory_raises(tmp_path: Path):
+    missing_dir = tmp_path / "nope"
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("data")
+
+    with pytest.raises(ValueError):
+        renamer.list_files(missing_dir)
+    with pytest.raises(ValueError):
+        renamer.list_files(file_path)
+
+
+def test_write_file_list_creates_output(tmp_path: Path):
+    create_files(tmp_path / "src", {"a.txt": "A", "b.txt": "B"})
+    output = tmp_path / "out" / "names.txt"
+
+    renamer.write_file_list(tmp_path / "src", output)
+
+    assert output.exists()
+    assert output.read_text().splitlines() == ["a.txt", "b.txt"]


### PR DESCRIPTION
## Summary
- add a Python CLI for exporting directory file names to a text file with options for recursion and hidden files
- document usage and configure pytest discovery
- add tests covering listing, recursion, hidden-file handling, and output writing
- add a Tkinter GUI launcher that becomes the default when no CLI arguments are provided
- document GUI usage and a PyInstaller command to build a Windows executable

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69413a9b3868832494852c5b6e99c36a)