### PR TITLE
Retry checkbox lookup after manual verification with quit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,73 @@ pyinstaller --onefile --windowed --name Renamer renamer.py
 
 생성된 `dist/Renamer.exe`를 실행하면 바로 GUI가 열립니다.
 
+## Grok 자동화 도구 (favorites 다운로드 + HD 업스케일 + 프롬프트 재실행)
+
+Grok 즐겨찾기 페이지에서 체크된 항목을 다운로드한 뒤 HD 업스케일을 적용하고, 기존에 사용한 프롬프트로 다시 영상을 돌리는 자동화 스크립트입니다.
+
+### 설치
+
+> 아래 명령은 **이 저장소 폴더에서** 실행해야 합니다. (예: `C:\path\to\Renamer`)
+
+```bash
+pip install -r requirements.txt
+python -m playwright install chromium
+```
+
+### 사용 방법
+
+> `python grok_automation.py`가 동작하지 않으면, 현재 터미널이 이 저장소 폴더인지 확인하세요.
+
+```bash
+python grok_automation.py --wait-login
+```
+
+주요 옵션:
+
+- `--profile-dir`: 로그인 세션을 저장하는 크롬 프로필 경로 (기본값: `grok_profile`)
+- `--download-dir`: 다운로드 저장 경로 (기본값: `downloads`)
+- `--headless`: 헤드리스 모드로 실행
+- `--max-items`: 처리할 체크 항목 수 제한 (0이면 제한 없음)
+- `--dry-run`: 체크된 항목만 확인하고 다운로드하지 않음
+- `--config`: 셀렉터를 JSON으로 오버라이드
+
+### 실행 파일 만들기 (Windows)
+
+```bash
+pip install pyinstaller
+pyinstaller --onefile --windowed --name GrokAutomation grok_automation.py
+```
+
+생성된 `dist/GrokAutomation.exe`를 실행하면 됩니다.
+
+### 문제 해결 (Windows)
+
+- `requirements.txt`를 찾을 수 없다는 오류가 나면, 먼저 저장소 폴더로 이동하세요.
+
+  ```bat
+  cd /d C:\path\to\Renamer
+  pip install -r requirements.txt
+  ```
+
+- `grok_automation.py`를 찾을 수 없다는 오류도 동일합니다. 아래처럼 저장소 폴더에서 실행하세요.
+
+  ```bat
+  cd /d C:\path\to\Renamer
+  python grok_automation.py --wait-login
+  ```
+
+### 셀렉터 설정
+
+Grok 페이지 UI가 바뀌면 셀렉터를 수정해야 할 수 있습니다. 예시 JSON:
+
+```json
+{
+  "checkbox_selector": "input[type=\"checkbox\"]",
+  "download_button_selector": "button:has-text(\"Download\")",
+  "hd_toggle_selector": "button:has-text(\"HD\")"
+}
+```
+
 ## 개발
 
 테스트 실행:

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ python grok_automation.py --wait-login
 - `--max-items`: 처리할 체크 항목 수 제한 (0이면 제한 없음)
 - `--dry-run`: 체크된 항목만 확인하고 다운로드하지 않음
 - `--config`: 셀렉터를 JSON으로 오버라이드
+- `--keep-open`: 작업 후 브라우저를 닫지 않고 유지
 
 ### 실행 파일 만들기 (Windows)
 

--- a/grok_automation.py
+++ b/grok_automation.py
@@ -1,0 +1,328 @@
+"""Automate Grok favorites downloads and reruns via Playwright."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+from playwright.sync_api import Error as PlaywrightError
+from playwright.sync_api import sync_playwright
+
+
+FAVORITES_URL = "https://grok.com/imagine/favorites"
+
+
+@dataclass(frozen=True)
+class GrokSelectors:
+    checkbox_selector: str
+    item_container_selector: str
+    download_button_selector: str
+    hd_toggle_selector: str
+    prompt_selector: str
+    prompt_input_selector: str
+    rerun_button_selector: str
+    open_item_selector: Optional[str] = None
+
+
+DEFAULT_SELECTORS = GrokSelectors(
+    checkbox_selector="input[type=\"checkbox\"]",
+    item_container_selector="article, div",
+    download_button_selector=(
+        "button:has-text(\"Download\"), a:has-text(\"Download\")"
+    ),
+    hd_toggle_selector="button:has-text(\"HD\"), button:has-text(\"Upscale\")",
+    prompt_selector=(
+        "[data-testid*=\"prompt\"], [data-prompt], .prompt, textarea"
+    ),
+    prompt_input_selector="textarea",
+    rerun_button_selector=(
+        "button:has-text(\"Regenerate\"), button:has-text(\"Generate\")"
+    ),
+    open_item_selector=None,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Grok favorites downloader with HD upscale + rerun",
+    )
+    parser.add_argument(
+        "--profile-dir",
+        type=Path,
+        default=Path("grok_profile"),
+        help="Persistent browser profile directory.",
+    )
+    parser.add_argument(
+        "--download-dir",
+        type=Path,
+        default=Path("downloads"),
+        help="Directory to store downloaded videos.",
+    )
+    parser.add_argument(
+        "--headless",
+        action="store_true",
+        help="Run browser in headless mode.",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        help="Optional JSON file to override selectors.",
+    )
+    parser.add_argument(
+        "--max-items",
+        type=int,
+        default=0,
+        help="Limit number of checked items to process (0 = no limit).",
+    )
+    parser.add_argument(
+        "--wait-login",
+        action="store_true",
+        help="Wait for manual login before continuing.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Only report matched items without downloading.",
+    )
+    parser.add_argument(
+        "--keep-open",
+        action="store_true",
+        help="Keep the browser open after automation completes.",
+    )
+    return parser
+
+
+def load_selectors(config_path: Optional[Path]) -> GrokSelectors:
+    if not config_path:
+        return DEFAULT_SELECTORS
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print(f"설정 파일을 찾지 못했습니다: {config_path}")
+        return DEFAULT_SELECTORS
+    except json.JSONDecodeError as exc:
+        print(
+            "설정 파일이 올바른 JSON 형식이 아닙니다. "
+            "HTML 파일을 지정했는지 확인하세요."
+        )
+        print(f"JSON 오류: {exc}")
+        return DEFAULT_SELECTORS
+    return GrokSelectors(**{**DEFAULT_SELECTORS.__dict__, **data})
+
+
+def prompt_for_login(wait_login: bool) -> None:
+    if not wait_login:
+        return
+    print("브라우저에서 Grok에 로그인하고 사람 인증을 완료한 뒤 Enter를 눌러 진행하세요.")
+    input()
+
+
+def wait_for_human_check(page) -> None:
+    try:
+        page.wait_for_url("**/imagine/favorites", timeout=30_000)
+        return
+    except PlaywrightTimeoutError:
+        print("즐겨찾기 페이지로 이동하지 못했습니다. 사람 인증 또는 로그인이 필요할 수 있습니다.")
+    print("브라우저에서 사람 인증(캡차)을 완료한 뒤 Enter를 눌러 진행하세요.")
+    input()
+
+
+def download_from_button(page, button, download_dir: Path, timeout_ms: int = 120_000) -> Path:
+    with page.expect_download(timeout=timeout_ms) as download_info:
+        button.click()
+    download = download_info.value
+    suggested = download.suggested_filename
+    target = download_dir / suggested
+    download.save_as(target)
+    return target
+
+
+def extract_prompt_text(item_handle, selectors: GrokSelectors) -> Optional[str]:
+    for selector in selectors.prompt_selector.split(","):
+        selector = selector.strip()
+        if not selector:
+            continue
+        handle = item_handle.query_selector(selector)
+        if handle:
+            prompt_value = handle.get_attribute("data-prompt")
+            if prompt_value:
+                return prompt_value.strip()
+            if handle.evaluate("el => 'value' in el"):
+                value = handle.get_attribute("value") or ""
+                if value.strip():
+                    return value.strip()
+            text = handle.inner_text().strip()
+            if text:
+                return text
+    return None
+
+
+def run_rerun(page, selectors: GrokSelectors, prompt_text: str) -> None:
+    input_locator = page.locator(selectors.prompt_input_selector)
+    if input_locator.count() == 0:
+        print("프롬프트 입력 칸을 찾지 못했습니다.")
+        return
+    input_box = input_locator.first
+    input_box.fill(prompt_text)
+    rerun_locator = page.locator(selectors.rerun_button_selector)
+    if rerun_locator.count() == 0:
+        print("재실행 버튼을 찾지 못했습니다.")
+        return
+    rerun_button = rerun_locator.first
+    rerun_button.click()
+
+
+def handle_item(page, item_handle, selectors: GrokSelectors, download_dir: Path) -> None:
+    if selectors.open_item_selector:
+        opener = item_handle.query_selector(selectors.open_item_selector)
+        if opener:
+            opener.click()
+            time.sleep(1.5)
+
+    hd_toggle = item_handle.query_selector(selectors.hd_toggle_selector)
+    if hd_toggle:
+        hd_toggle.click()
+        time.sleep(0.5)
+
+    download_button = item_handle.query_selector(selectors.download_button_selector)
+    if not download_button:
+        download_button = page.query_selector(selectors.download_button_selector)
+
+    if download_button:
+        downloaded_path = download_from_button(page, download_button, download_dir)
+        print(f"다운로드 완료: {downloaded_path}")
+    else:
+        print("다운로드 버튼을 찾지 못했습니다.")
+
+    prompt_text = extract_prompt_text(item_handle, selectors)
+    if not prompt_text:
+        prompt_text = extract_prompt_text(page, selectors)
+
+    if prompt_text:
+        run_rerun(page, selectors, prompt_text)
+        print("프롬프트 재실행 완료")
+    else:
+        print("프롬프트를 찾지 못했습니다.")
+
+
+def safe_query_checkboxes(page, selectors: GrokSelectors, retries: int = 3):
+    last_error: Optional[Exception] = None
+    for attempt in range(1, retries + 1):
+        try:
+            page.wait_for_load_state("domcontentloaded", timeout=30_000)
+            return page.query_selector_all(selectors.checkbox_selector)
+        except PlaywrightError as exc:
+            last_error = exc
+            message = str(exc)
+            if "Execution context was destroyed" in message and attempt < retries:
+                time.sleep(1.0)
+                continue
+            raise
+    if last_error:
+        raise last_error
+
+
+def run_automation(
+    profile_dir: Path,
+    download_dir: Path,
+    selectors: GrokSelectors,
+    *,
+    headless: bool,
+    wait_login: bool,
+    max_items: int,
+    dry_run: bool,
+    keep_open: bool,
+) -> int:
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    download_dir.mkdir(parents=True, exist_ok=True)
+
+    with sync_playwright() as playwright:
+        context = playwright.chromium.launch_persistent_context(
+            user_data_dir=str(profile_dir),
+            headless=headless,
+            accept_downloads=True,
+        )
+        page = context.new_page()
+        page.goto(FAVORITES_URL, wait_until="domcontentloaded")
+        prompt_for_login(wait_login)
+        wait_for_human_check(page)
+
+        if page.is_closed():
+            print("브라우저가 닫혀 자동화를 진행할 수 없습니다.")
+            context.close()
+            return 1
+
+        try:
+            checkboxes = safe_query_checkboxes(page, selectors)
+            while wait_login and not checkboxes:
+                print(
+                    "체크박스를 찾지 못했습니다. 사람 인증/로그인을 마친 뒤 Enter로 재시도하거나 "
+                    "'q'를 입력해 종료하세요."
+                )
+                response = input().strip().lower()
+                if response == "q":
+                    if keep_open:
+                        input("브라우저를 닫기 전에 Enter를 누르세요.")
+                    context.close()
+                    return 0
+                checkboxes = safe_query_checkboxes(page, selectors)
+        except PlaywrightError as exc:
+            print(f"페이지가 닫혔거나 접근할 수 없습니다: {exc}")
+            context.close()
+            return 1
+        checked_items = []
+        for checkbox in checkboxes:
+            if checkbox.is_checked():
+                container_handle = checkbox.evaluate_handle(
+                    "(el, selector) => el.closest(selector)",
+                    selectors.item_container_selector,
+                )
+                container = container_handle.as_element()
+                if container:
+                    checked_items.append(container)
+
+        if max_items > 0:
+            checked_items = checked_items[:max_items]
+
+        print(f"선택된 항목 수: {len(checked_items)}")
+        if dry_run:
+            if keep_open:
+                input("브라우저를 닫기 전에 Enter를 누르세요.")
+            context.close()
+            return 0
+
+        for item in checked_items:
+            handle_item(page, item, selectors, download_dir)
+
+        if keep_open:
+            input("브라우저를 닫기 전에 Enter를 누르세요.")
+        context.close()
+
+    return 0
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    selectors = load_selectors(args.config)
+
+    return run_automation(
+        args.profile_dir,
+        args.download_dir,
+        selectors,
+        headless=args.headless,
+        wait_login=args.wait_login,
+        max_items=args.max_items,
+        dry_run=args.dry_run,
+        keep_open=args.keep_open,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+playwright==1.45.0


### PR DESCRIPTION
### Motivation

- Prevent the automation from exiting immediately when Playwright requires manual human verification (captcha/login) and no checkboxes are found.
- Reduce flakiness caused by Playwright execution-context resets during selector queries.
- Let the operator retry checkbox discovery interactively after completing verification instead of forcing an immediate failure.
- Allow a graceful exit that can optionally keep the browser open for inspection.

### Description

- Modify `grok_automation.py` to repeatedly call `safe_query_checkboxes` while `--wait-login` is enabled and no checkboxes are returned, prompting the user between attempts.
- Add an interactive quit path where entering `'q'` will exit the automation gracefully and honor `--keep-open` to leave the browser open for inspection.
- Retain `safe_query_checkboxes` retry behavior for handling `"Execution context was destroyed"` errors during selector queries.
- Update `README.md` with Grok automation usage and add `requirements.txt` pinning `playwright==1.45.0`.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69501d02af388324a424214a5fb47f52)